### PR TITLE
new versions of influx and illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
   },
   "require": {
     "php": "^7.1.3",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3|^7.0",
     "illuminate/support": "^5.5|^6.0|^7.0",
     "influxdb/influxdb-php": "^1.15",
     "monolog/monolog": "^1.12|^2.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "^3.5|^4.0",
+    "orchestra/testbench": "^3.5|^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0",
     "squizlabs/php_codesniffer": "^3.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   "require": {
     "php": "^7.1.3",
     "guzzlehttp/guzzle": "^6.3",
-    "illuminate/support": "^5.5|^6.0",
-    "influxdb/influxdb-php": "^1.14",
+    "illuminate/support": "^5.5|^6.0|^7.0",
+    "influxdb/influxdb-php": "^1.15",
     "monolog/monolog": "^1.12|^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
Current version can't be installed on my laravel 6
Gives me errors
```
    - oanhnn/laravel-influxdb v0.1.0 requires illuminate/support ^5.5 -> satisfiable by illuminate/support[5.5.x-dev, 5.6.x-dev, 5.7.17, 5.7.18, 5.7.19, 5.7.x-dev, 5.8.x-dev, v5.5.0, v5.5.16, v5.5.17, v5.5.2, v5.5.28, v5.5.33, v5.5.34, v5.5.35, v5.5.36, v5.5.37, v5.5.39, v5.5.40, v5.5.41, v5.5.43, v5.5.44, v5.6.0, v5.6.1, v5.6.10, v5.6.11, v5.6.12, v5.6.13, v5.6.14, v5.6.15, v5.6.16, v5.6.17, v5.6.19, v5.6.2, v5.6.20, v5.6.21, v5.6.22, v5.6.23, v5.6.24, v5.6.25, v5.6.26, v5.6.27, v5.6.28, v5.6.29, v5.6.3, v5.6.30, v5.6.31, v5.6.32, v5.6.33, v5.6.34, v5.6.35, v5.6.36, v5.6.37, v5.6.38, v5.6.39, v5.6.4, v5.6.5, v5.6.6, v5.6.7, v5.6.8, v5.6.9, v5.7.0, v5.7.1, v5.7.10, v5.7.11, v5.7.15, v5.7.2, v5.7.20, v5.7.21, v5.7.22, v5.7.23, v5.7.26, v5.7.27, v5.7.28, v5.7.3, v5.7.4, v5.7.5, v5.7.6, v5.7.7, v5.7.8, v5.7.9, v5.8.0, v5.8.11, v5.8.12, v5.8.14, v5.8.15, v5.8.17, v5.8.18, v5.8.19, v5.8.2, v5.8.20, v5.8.22, v5.8.24, v5.8.27, v5.8.28, v5.8.29, v5.8.3, v5.8.30, v5.8.31, v5.8.32, v5.8.33, v5.8.34, v5.8.35, v5.8.36, v5.8.4, v5.8.8, v5.8.9].
    - don't install illuminate/support 5.8.x-dev|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.0|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.11|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.12|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.14|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.15|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.17|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.18|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.19|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.2|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.20|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.22|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.24|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.27|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.28|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.29|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.3|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.30|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.31|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.32|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.33|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.34|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.35|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.36|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.4|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.8|don't install laravel/framework v6.12.0
    - don't install illuminate/support v5.8.9|don't install laravel/framework v6.12.0
    - Installation request for laravel/framework (locked at v6.12.0, required as ^6.0) -> satisfiable by laravel/framework[v6.12.0].
```
Updated versions in composer.json